### PR TITLE
feat: Add `momenta-router` and switch docs to hash-based routing

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -34,7 +34,9 @@ name = "docs"
 version = "0.1.0"
 dependencies = [
  "momenta",
+ "momenta-router",
  "wasm-bindgen",
+ "web-sys",
 ]
 
 [[package]]
@@ -64,6 +66,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "13dc2df351e3202783a1fe0d44375f7295ffb4049267b0f3018346dc122a1d94"
 
 [[package]]
+name = "matchit"
+version = "0.8.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2f926ade0c4e170215ae43342bf13b9310a437609c81f29f86c5df6657582ef9"
+
+[[package]]
 name = "memchr"
 version = "2.7.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -90,6 +98,16 @@ dependencies = [
  "quote",
  "regex",
  "syn",
+]
+
+[[package]]
+name = "momenta-router"
+version = "0.1.0"
+dependencies = [
+ "matchit",
+ "momenta",
+ "wasm-bindgen",
+ "web-sys",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,3 +1,3 @@
 [workspace]
-members = ["momenta-macros", "momenta", "tests", "docs"]
+members = ["momenta-macros", "momenta", "tests", "docs", "momenta-router"]
 resolver = "3"

--- a/docs/Cargo.toml
+++ b/docs/Cargo.toml
@@ -6,4 +6,6 @@ metadata.workspace = true
 
 [dependencies]
 momenta = { path = "../momenta", features = ["wasm"] }
+momenta-router = { path = "../momenta-router" }
 wasm-bindgen = { version = "0.2" }
+web-sys = { version = "0.3", features = ["Window", "Location", "History"] }

--- a/momenta-macros/src/lib.rs
+++ b/momenta-macros/src/lib.rs
@@ -927,7 +927,7 @@ impl RsxNode {
                         if name.is_none() {
                             return quote_spanned! {span=> #value };
                         }
-                        quote_spanned! {span=> #name: {#value}.into(), }
+                        quote_spanned! {span=> #[allow(clippy::useless_conversion)] #name: {#value}.into(), }
                     });
 
                 let children_tokens = if !children.is_empty() || is_element {

--- a/momenta-router/Cargo.toml
+++ b/momenta-router/Cargo.toml
@@ -1,0 +1,10 @@
+[package]
+name = "momenta-router"
+version = "0.1.0"
+edition = "2024"
+
+[dependencies]
+momenta = { path = "../momenta" }
+matchit = "0.8"
+web-sys = { version = "0.3", features = ["Window", "Location", "History", "Event", "PopStateEvent", "EventTarget"] }
+wasm-bindgen = "0.2"

--- a/momenta-router/src/lib.rs
+++ b/momenta-router/src/lib.rs
@@ -1,0 +1,161 @@
+#![no_std]
+
+extern crate alloc;
+
+use alloc::{
+    boxed::Box,
+    format,
+    string::{String, ToString},
+    vec::Vec,
+};
+use momenta::prelude::*;
+use wasm_bindgen::JsCast;
+use wasm_bindgen::prelude::*;
+use web_sys::Event;
+
+pub use matchit::Router;
+
+#[derive(Clone, Copy, PartialEq, Eq)]
+pub enum RouterMode {
+    Hash,
+    Pathname,
+}
+
+#[derive(Clone, Copy)]
+pub struct RouterContext {
+    mode: RouterMode,
+    current_path: Signal<&'static str>,
+}
+
+impl RouterContext {
+    pub fn new(mode: RouterMode) -> Self {
+        let current_path = create_signal(Self::get_initial_path(mode));
+        Self::setup_listener(mode, current_path);
+        Self { mode, current_path }
+    }
+    pub fn with_path(mode: RouterMode, path: &'static str) -> Self {
+        let current_path = create_signal(path);
+        Self::setup_listener(mode, current_path);
+        Self { mode, current_path }
+    }
+
+    fn get_initial_path(mode: RouterMode) -> &'static str {
+        let window = web_sys::window().unwrap();
+        let location = window.location();
+
+        let path_string = match mode {
+            RouterMode::Hash => location
+                .hash()
+                .unwrap_or_default()
+                .trim_start_matches('#')
+                .to_string(),
+            RouterMode::Pathname => location
+                .pathname()
+                .unwrap_or_default()
+                .trim_start_matches('/')
+                .to_string(),
+        };
+
+        let path = if path_string.is_empty() {
+            "/".to_string()
+        } else {
+            path_string
+        };
+
+        Box::leak(path.into_boxed_str())
+    }
+
+    fn setup_listener(mode: RouterMode, current_path: Signal<&'static str>) {
+        let window = web_sys::window().unwrap();
+
+        let closure = Closure::wrap(alloc::boxed::Box::new(move |_event: Event| {
+            let new_path = Self::get_initial_path(mode);
+            current_path.set(new_path);
+        }) as alloc::boxed::Box<dyn FnMut(_)>);
+
+        window
+            .add_event_listener_with_callback("popstate", closure.as_ref().unchecked_ref())
+            .unwrap();
+
+        closure.forget();
+    }
+
+    pub fn navigate(&self, path: &str) {
+        let window = web_sys::window().unwrap();
+        let history = window.history().unwrap();
+
+        match self.mode {
+            RouterMode::Hash => {
+                let hash_path = format!("#{}", path);
+                window.location().set_hash(&hash_path).unwrap();
+            }
+            RouterMode::Pathname => {
+                history
+                    .push_state_with_url(&JsValue::NULL, "", Some(path))
+                    .unwrap();
+                // Manually trigger path update since pushState doesn't fire popstate
+                let leaked_path = Box::leak(path.to_string().into_boxed_str());
+                self.current_path.set(leaked_path);
+            }
+        }
+    }
+
+    pub fn current_path(&self) -> Signal<&'static str> {
+        self.current_path
+    }
+}
+
+pub struct RouteMatch {
+    pub params: Vec<(String, String)>,
+}
+
+impl RouteMatch {
+    pub fn get(&self, key: &str) -> Option<&str> {
+        self.params
+            .iter()
+            .find(|(k, _)| k == key)
+            .map(|(_, v)| v.as_str())
+    }
+}
+
+#[macro_export]
+macro_rules! routes {
+    (
+        $router:expr,
+        $path:expr,
+        {
+            $($pattern:literal => $handler:expr),* $(,)?
+        }
+    ) => {{
+        use alloc::string::ToString;
+
+        let mut matcher = $crate::Router::new();
+        $(
+            matcher.insert($pattern, $pattern).unwrap();
+        )*
+
+        let path = $path.get();
+        let matched = matcher.at(&path);
+
+        match matched {
+            Ok(m) => {
+                let route_pattern = *m.value;
+                let params: alloc::vec::Vec<(alloc::string::String, alloc::string::String)> = m
+                    .params
+                    .iter()
+                    .map(|(k, v)| (k.to_string(), v.to_string()))
+                    .collect();
+
+                let route_match = $crate::RouteMatch { params };
+
+                match route_pattern {
+                    $(
+                        $pattern => $handler(route_match),
+                    )*
+                    _ => momenta::nodes::Node::Empty,
+                }
+            }
+            Err(_) => momenta::nodes::Node::Empty,
+        }
+    }};
+}

--- a/momenta/src/nodes.rs
+++ b/momenta/src/nodes.rs
@@ -530,8 +530,11 @@ fn sanitize_html(input: &str) -> String {
 }
 
 #[cfg(feature = "wasm")]
+type EventCallbackInner = Arc<spin::Mutex<Box<dyn FnMut(web_sys::Event) + Send + Sync>>>;
+
+#[cfg(feature = "wasm")]
 #[derive(Default)]
-pub struct EventCallback(Option<Arc<spin::Mutex<Box<dyn FnMut(web_sys::Event) + Send + Sync>>>>);
+pub struct EventCallback(Option<EventCallbackInner>);
 
 #[cfg(feature = "wasm")]
 impl EventCallback {

--- a/momenta/src/signals.rs
+++ b/momenta/src/signals.rs
@@ -37,17 +37,19 @@ static SIGNALS: Mutex<BTreeMap<(usize, usize), StoredValue>> = Mutex::new(BTreeM
 /// Signals that changed during current scope execution
 static SCOPE_SIGNAL_CHANGES: Mutex<BTreeSet<(usize, usize)>> = Mutex::new(BTreeSet::new());
 
+type ScopeCallback = Arc<dyn Fn(&Node) + Send + Sync>;
+type ScopeEffect = Box<dyn Fn() + Send>;
+type ScopeEffectCleanup = Box<dyn FnOnce() + Send>;
+
 /// Functions that can be re-executed per scope
 static SCOPE_FUNCTIONS: Mutex<BTreeMap<usize, Box<dyn FnMut() -> Node + Send>>> =
     Mutex::new(BTreeMap::new());
 /// Callbacks to run after scope renders
-static SCOPE_CALLBACKS: Mutex<BTreeMap<usize, Arc<dyn Fn(&Node) + Send + Sync>>> =
-    Mutex::new(BTreeMap::new());
+static SCOPE_CALLBACKS: Mutex<BTreeMap<usize, ScopeCallback>> = Mutex::new(BTreeMap::new());
 /// Effects by (scope_id, effect_id)
-static SCOPE_EFFECTS: Mutex<BTreeMap<(usize, usize), Box<dyn Fn() + Send>>> =
-    Mutex::new(BTreeMap::new());
+static SCOPE_EFFECTS: Mutex<BTreeMap<(usize, usize), ScopeEffect>> = Mutex::new(BTreeMap::new());
 /// Effect cleanup functions by (scope_id, effect_id)
-static SCOPE_EFFECT_CLEANUPS: Mutex<BTreeMap<(usize, usize), Box<dyn FnOnce() + Send>>> =
+static SCOPE_EFFECT_CLEANUPS: Mutex<BTreeMap<(usize, usize), ScopeEffectCleanup>> =
     Mutex::new(BTreeMap::new());
 
 /// Which signals each scope depends on


### PR DESCRIPTION
This PR includes work on `momenta-router`. 

This is something I should have done much earlier except I was initially trying to make it work using components. I do not advise this approach for any reason. using `routes!` macro is way more efficient.

The router also uses matchit underhood for speed in matching routes