### PR TITLE
fix: harden SSR output escaping

### DIFF
--- a/momenta-core/src/nodes.rs
+++ b/momenta-core/src/nodes.rs
@@ -61,8 +61,58 @@ fn write_escaped_text(text: &str, w: &mut impl core::fmt::Write) -> core::fmt::R
     Ok(())
 }
 
-/// Write a node's HTML to any `fmt::Write` sink (String, Formatter, etc.).
+/// Write an escaped HTML attribute value to any `fmt::Write` sink.
+///
+/// Attribute values are double-quoted in the output, so `"` and `&` must be
+/// escaped to prevent the value from breaking out and injecting a new
+/// attribute. `<` and `>` are escaped too for defense in depth. A hostile
+/// value like `" onmouseover="alert(1)` must remain a single attribute value,
+/// never a new attribute.
 #[inline]
+fn write_escaped_attribute_value(text: &str, w: &mut impl core::fmt::Write) -> core::fmt::Result {
+    if !text
+        .bytes()
+        .any(|b| matches!(b, b'&' | b'"' | b'<' | b'>'))
+    {
+        return w.write_str(text);
+    }
+    for c in text.chars() {
+        match c {
+            '&' => w.write_str("\x26amp;")?,
+            '"' => w.write_str("\x26quot;")?,
+            '<' => w.write_str("\x26lt;")?,
+            '>' => w.write_str("\x26gt;")?,
+            _ => w.write_char(c)?,
+        }
+    }
+    Ok(())
+}
+
+/// Escape comment content so it cannot break out of an HTML comment.
+///
+/// Escape comment content so it cannot break out of an HTML comment.
+///
+/// HTML comment text must not contain `-->` or `--!>`, and the spec forbids
+/// `--` inside comments. Neutralize the close sequences first, then split
+/// any remaining `--` so no comment-closing sequence can form.
+#[inline]
+fn escape_comment_content(comment: &str, w: &mut impl core::fmt::Write) -> core::fmt::Result {
+    let neutralized = comment.replace("--!>", "- -!>").replace("-->", "- ->");
+    let bytes = neutralized.as_bytes();
+    let mut wrote = 0usize;
+    let mut i = 0usize;
+    while i + 1 < bytes.len() {
+        if bytes[i] == b'-' && bytes[i + 1] == b'-' {
+            w.write_str(&neutralized[wrote..i])?;
+            w.write_str("- -")?;
+            i += 2;
+            wrote = i;
+        } else {
+            i += 1;
+        }
+    }
+    w.write_str(&neutralized[wrote..])
+}
 fn write_node_html(node: &Node, w: &mut impl core::fmt::Write) -> core::fmt::Result {
     match node {
         Node::Element(el) => {
@@ -72,7 +122,7 @@ fn write_node_html(node: &Node, w: &mut impl core::fmt::Write) -> core::fmt::Res
                 w.write_str(" ")?;
                 w.write_str(key)?;
                 w.write_str("=\"")?;
-                w.write_str(value)?;
+                write_escaped_attribute_value(value, w)?;
                 w.write_str("\"")?;
             }
             w.write_str(">")?;
@@ -95,7 +145,7 @@ fn write_node_html(node: &Node, w: &mut impl core::fmt::Write) -> core::fmt::Res
         }
         Node::Comment(comment) => {
             w.write_str("<!--")?;
-            w.write_str(comment)?;
+            escape_comment_content(comment, w)?;
             w.write_str("-->")?;
         }
         Node::Static(html) => w.write_str(html)?,

--- a/momenta-macros/src/lib.rs
+++ b/momenta-macros/src/lib.rs
@@ -1088,12 +1088,12 @@ impl RsxNode {
                             .unwrap_or(false)
                     }))
                 .then(|| {
-                    let timestamp = std::time::SystemTime::now()
-                        .duration_since(std::time::UNIX_EPOCH)
-                        .unwrap_or_else(|_| std::time::Duration::from_secs(0))
-                        .as_nanos()
-                        .to_string();
-                    let ident = syn::Ident::new(&format!("attr_data_{}", timestamp), *open_span);
+                    // Use a fixed hygienic local identifier instead of a
+                    // wall-clock timestamp. Proc-macro hygiene gives each
+                    // expansion its own scope, so a fixed name cannot collide
+                    // with user code or sibling expansions. This makes macro
+                    // expansion deterministic (reproducible builds).
+                    let ident = syn::Ident::new("attr_data", *open_span);
                     let data = attrs
                         .clone()
                         .filter(|(name, _, _)| {

--- a/momenta-ssr/src/lib.rs
+++ b/momenta-ssr/src/lib.rs
@@ -101,7 +101,7 @@ pub fn render_to_hydration_string(
 pub fn render_hydration_state_script(script_id: &str, state_json: &str) -> String {
     let mut output = String::new();
     output.push_str("<script id=\"");
-    output.push_str(script_id);
+    output.push_str(&escape_attribute_value(script_id));
     output.push_str("\" type=\"application/json\">");
     output.push_str(&escape_script_content(state_json));
     output.push_str("</script>");
@@ -297,7 +297,7 @@ fn write_node_to_collector(node: &Node, collector: &mut ChunkCollector) {
         }
         Node::Comment(comment) => {
             collector.push_str("<!--");
-            collector.push_str(comment);
+            collector.push_str(&escape_comment(comment));
             collector.push_str("-->");
         }
         Node::Static(html) => collector.push_str(html),
@@ -334,7 +334,7 @@ fn write_node_to_collector_hydratable(
         }
         Node::Comment(comment) => {
             collector.push_str("<!--");
-            collector.push_str(comment);
+            collector.push_str(&escape_comment(comment));
             collector.push_str("-->");
         }
         Node::Static(html) => collector.push_str(html),
@@ -394,7 +394,7 @@ fn write_attribute(collector: &mut ChunkCollector, key: &str, value: &str) {
     collector.push_str(" ");
     collector.push_str(key);
     collector.push_str("=\"");
-    collector.push_str(value);
+    collector.push_str(&escape_attribute_value(value));
     collector.push_str("\"");
 }
 
@@ -432,6 +432,33 @@ fn write_escaped_text(text: &str, collector: &mut ChunkCollector) {
             _ => collector.push_char(ch),
         }
     }
+}
+
+/// Escape a value placed inside a double-quoted HTML attribute.
+///
+/// `"` and `&` must be escaped to prevent breakout; `<` and `>` are escaped
+/// for defense in depth. Used for both element attribute values and the
+/// `id="..."` of the hydration state <script>.
+fn escape_attribute_value(text: &str) -> String {
+    let mut out = String::with_capacity(text.len());
+    for c in text.chars() {
+        match c {
+            '\x26' => out.push_str("\x26amp;"),
+            '"' => out.push_str("\x26quot;"),
+            '<' => out.push_str("\x26lt;"),
+            '>' => out.push_str("\x26gt;"),
+            _ => out.push(c),
+        }
+    }
+    out
+}
+
+/// Escape comment content so `-->` and `--!>` cannot form and break out.
+/// The HTML spec forbids `--` inside comments; splitting every `--` into
+/// `- -` is the minimal correct transformation.
+fn escape_comment(text: &str) -> String {
+    let n = text.replace("--!>", "- -!>").replace("-->", "- ->");
+    n.replace("--", "- -")
 }
 
 fn escape_script_content(text: &str) -> String {
@@ -584,4 +611,62 @@ mod tests {
             "<script id=\"state\" type=\"application/json\">\\u003c/script\\u003e\\u003cdiv\\u003e</script>"
         );
     }
+
+
+    #[test]
+    fn attribute_value_with_quote_does_not_inject_new_attribute() {
+        // A hostile value with `"` must be escaped so it cannot close the
+        // attribute and inject a new one. The quote becomes " inside the
+        // value; "onmouseover=" with an UNESCAPED quote must not appear.
+        let hostile = "\" onmouseover=\"alert(1)";
+        let node = Element::parse_tag_with_attributes(
+            "",
+            "div",
+            vec![("title".to_string(), hostile.to_string())],
+            Vec::new(),
+            "",
+            Vec::new(),
+        );
+        let html = render_to_string(|| node);
+        assert!(
+            !html.contains("onmouseover=\"alert"),
+            "attribute injection: unescaped quote created a new attribute: {}",
+            html
+        );
+        assert!(html.contains("&quot;"), "quote not escaped: {}", html);
+        assert!(html.contains("title="), "title missing: {}", html);
+    }
+
+    #[test]
+    fn comment_cannot_break_out_with_close_sequence() {
+        let payload = "--><script>alert(1)</script>";
+        let node = Element::parse_tag_with_attributes(
+            "",
+            "div",
+            Vec::new(),
+            Vec::new(),
+            "",
+            vec![Node::Comment(payload.to_string()), element("p", vec![Node::from("x")])],
+        );
+        let html = render_to_string(|| node);
+        assert!(
+            !html.contains("--><script"),  // breakout = close-seq immediately followed by script
+            "comment breakout injected a script: {}",
+            html
+        );
+    }
+
+    #[test]
+    fn hydration_script_id_with_quote_does_not_inject_attribute() {
+        let hostile = "\" onmouseover=\"alert(1)";
+        let script = render_hydration_state_script(hostile, "{}");
+        assert!(
+            !script.contains("onmouseover=\"alert"),
+            "script_id broke out of id attribute: {}",
+            script
+        );
+        assert!(script.contains("&quot;"), "quote not escaped: {}", script);
+    }
+
 }
+


### PR DESCRIPTION
This came out of the Arcature integration work from #40.

While testing Momenta's SSR path, I found a few cases where generated HTML could break out of its intended context.

This PR fixes:

- attribute values not being escaped before being written into quoted HTML attributes
- HTML comment content being able to close the comment with `-->`
- custom hydration script ids not being escaped
- RSX macro expansion using `SystemTime::now()` just to generate a local identifier

The macro identifier is now deterministic and relies on Rust macro hygiene instead of wall-clock time.

I also added regression tests for the SSR escaping cases.

I intentionally kept the larger findings out of this PR. The audit also found separate issues around concurrent SSR runtime state, panic cleanup, hydration props, and some HTML semantics. Those are better handled independently.

Validation completed locally:

- full workspace tests pass
- `momenta-ssr` tests pass, including the new regression cases
- clippy passes

Feel free to adjust the implementation if you prefer a different approach before merging.